### PR TITLE
Modernize/cache.cc

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -16,6 +16,7 @@
 #include "inout.h"
 #include "log.h"
 #include "torrent.h"
+#include "torrents.h"
 #include "tr-assert.h"
 #include "trevent.h"
 #include "utils.h"
@@ -198,8 +199,9 @@ int Cache::setLimit(int64_t new_limit)
     return cacheTrim();
 }
 
-Cache::Cache(int64_t max_bytes)
-    : max_blocks_(getMaxBlocks(max_bytes))
+Cache::Cache(tr_torrents& torrents, int64_t max_bytes)
+    : torrents_{ torrents }
+    , max_blocks_(getMaxBlocks(max_bytes))
     , max_bytes_(max_bytes)
 {
 }

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -4,7 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <cstdlib> // std::lldiv()
-#include <iterator> // std::back_inserter, std::distance(), std::next(), std::prev()
+#include <iterator> // std::distance(), std::next(), std::prev()
 #include <limits> // std::numeric_limits<size_t>::max()
 #include <numeric> // std::accumulate()
 #include <utility> // std::make_pair()
@@ -82,7 +82,7 @@ int Cache::writeContiguous(CIter const begin, CIter const end) const
     {
         TR_ASSERT(begin->key.first == iter->key.first);
         TR_ASSERT(begin->key.second + std::distance(begin, iter) == iter->key.second);
-        std::copy(std::begin(iter->buf), std::end(iter->buf), std::back_inserter(buf));
+        buf.insert(std::end(buf), std::begin(iter->buf), std::end(iter->buf));
     }
     TR_ASSERT(std::size(buf) == buflen);
 

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -75,6 +75,9 @@ private:
     [[nodiscard]] int flushSpan(CIter const begin, CIter const end);
 
     // @return any error code from writeContiguous()
+    [[nodiscard]] int flushOldest();
+
+    // @return any error code from writeContiguous()
     [[nodiscard]] int cacheTrim();
 
     [[nodiscard]] static size_t getMaxBlocks(int64_t max_bytes) noexcept;

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -16,13 +16,14 @@
 
 #include "block-info.h"
 
+class tr_torrents;
 struct evbuffer;
 struct tr_torrent;
 
 class Cache
 {
 public:
-    explicit Cache(int64_t max_bytes);
+    explicit Cache(tr_torrents& torrents, int64_t max_bytes);
     ~Cache() = default;
 
     int setLimit(int64_t new_limit);
@@ -71,6 +72,8 @@ private:
         DONEFLAG = 0x2000,
         SESSIONFLAG = 0x4000,
     };
+
+    tr_torrents& torrents_;
 
     std::vector<CacheBlock> blocks_;
     size_t max_blocks_ = 0;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -606,7 +606,7 @@ tr_session* tr_sessionInit(char const* config_dir, bool messageQueuingEnabled, t
     auto* session = new tr_session{};
     session->udp_socket = TR_BAD_SOCKET;
     session->udp6_socket = TR_BAD_SOCKET;
-    session->cache = std::make_unique<Cache>(1024 * 1024 * 2);
+    session->cache = std::make_unique<Cache>(session->torrents(), 1024 * 1024 * 2);
     session->magicNumber = SESSION_MAGIC_NUMBER;
     session->session_id = tr_session_id_new();
     bandwidthGroupRead(session, config_dir);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -566,11 +566,6 @@ static void onSaveTimer(evutil_socket_t /*fd*/, short /*what*/, void* vsession)
 {
     auto* session = static_cast<tr_session*>(vsession);
 
-    if (session->cache->flushDone() != 0)
-    {
-        tr_logAddError("Error while flushing completed pieces from cache");
-    }
-
     for (auto* const tor : session->torrents())
     {
         tr_torrentSave(tor);


### PR DESCRIPTION
@kvakvs To be honest, tracking down the bugs in the new code was so frustrating -- because of the existing code, not because of your changes -- that I wound up just removing the problematic pre-existing code and used simpler replacements instead. 

- replacing the raw `tr_torrent` pointer and `block_info::Location` with a `std::pair Key` type
- replacing the evbuffer with a `std::vector` so that we don't need to do raw pointer memory management
- removing the whole `rank` step to find which blocks to prune; just remove the contiguous span that has the oldest block

As a result, the tests & sanitizers work now and the code is simpler, but it's also a pretty big diff :dizzy:  For that reason, I thought I'd PR it and see what you think instead of just merging it without talking it over first.

I'm happy to make changes if requested; also happy to pass the baton if you want to do more work on it. It's all good to me.